### PR TITLE
Feat: Added the build scripts

### DIFF
--- a/scripts/build-manifest.js
+++ b/scripts/build-manifest.js
@@ -1,0 +1,37 @@
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { writeFileSync, mkdirSync } from 'fs';
+import chromeManifest from '../manifests/manifest.config.chrome.js';
+import firefoxManifest from '../manifests/manifest.config.firefox.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// check directories  = true
+const chromeDir = join(__dirname, '../dist/chrome');
+const firefoxDir = join(__dirname, '../dist/firefox');
+
+try {
+  // if no directorys, we create one
+  mkdirSync(chromeDir, { recursive: true });
+  mkdirSync(firefoxDir, { recursive: true });
+
+  // Generate Chrome manifest
+  writeFileSync(
+    join(chromeDir, 'manifest.json'),
+    JSON.stringify(chromeManifest, null, 2),
+    'utf-8'
+  );
+  console.log('✓ Chrome manifest generated');
+
+  // Generate Firefox manifest
+  writeFileSync(
+    join(firefoxDir, 'manifest.json'),
+    JSON.stringify(firefoxManifest, null, 2),
+    'utf-8'
+  );
+  console.log('✓ Firefox manifest generated');
+} catch (error) {
+  console.error('Error generating manifests:', error);
+  process.exit(1);
+}

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -1,0 +1,35 @@
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { existsSync, mkdirSync, copyFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const browsers = ['chrome', 'firefox'];
+const iconSizes = ['16', '32', '48', '96', '128'];
+
+// Create dist directories if none exist
+browsers.forEach(browser => {
+  const distPath = join(__dirname, `../dist/${browser}`);
+  const iconPath = join(distPath, 'icon');
+  
+  if (!existsSync(distPath)) {
+    mkdirSync(distPath, { recursive: true });
+  }
+  
+  if (!existsSync(iconPath)) {
+    mkdirSync(iconPath, { recursive: true });
+  }
+  
+  // for the icons
+  iconSizes.forEach(size => {
+    const sourceIcon = join(__dirname, `../public/icon/${size}.png`);
+    const targetIcon = join(iconPath, `${size}.png`);
+    
+    if (existsSync(sourceIcon)) {
+      copyFileSync(sourceIcon, targetIcon);
+    } else {
+      console.warn(`Warning: Icon ${size}.png not found in public/icon directory`);
+    }
+  });
+});

--- a/scripts/e-handler.js
+++ b/scripts/e-handler.js
@@ -1,0 +1,25 @@
+import { copyFileSync, mkdirSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const browsers = ['chrome', 'firefox'];
+
+browsers.forEach(browser => {
+  const srcPath = resolve(__dirname, '../dist/temp/epub-handler.iife.js');
+  const destDir = resolve(__dirname, `../dist/${browser}/src`);
+  const destPath = resolve(destDir, 'epub-handler.js');
+  
+  // Check if source file exists
+  if (!existsSync(srcPath)) {
+    console.error(`Source file not found: ${srcPath}`);
+    console.error('Make sure to run build:content first');
+    process.exit(1);
+  }
+  
+  mkdirSync(destDir, { recursive: true });
+  copyFileSync(srcPath, destPath);
+  console.log(`Copied content script to dist/${browser}/src/epub-handler.js`);
+});

--- a/scripts/increment-version.js
+++ b/scripts/increment-version.js
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Version sequence pattern:
+ * 0.0.1 -> 0.1.0 -> 0.1.1 -> 0.2.0 -> 0.2.1 -> 0.2.2 -> 0.3.0 -> 0.3.1 -> 0.3.2 -> 0.3.3 -> 0.4.0...
+ * 
+ * Stable versions: 0.0.1, 0.1.1, 0.2.2, 0.3.3, 0.4.4, etc. (minor == patch)
+ * 
+ * Logic:
+ * - If patch < minor: increment patch
+ * - If patch == minor: increment minor, set patch to 0
+ * 
+ * Edits by: rezzcode/the1Riddle
+ */
+function getNextVersion(currentVersion) {
+  const [major, minor, patch] = currentVersion.split('.').map(Number);
+  
+  if (patch < minor) {
+    // Increment patch
+    return `${major}.${minor}.${patch + 1}`;
+  } else {
+    // patch == minor, so increment minor and reset patch to 0
+    return `${major}.${minor + 1}.0`;
+  }
+}
+
+// Read package.json
+const packageJsonPath = join(__dirname, '../package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+
+const currentVersion = packageJson.version;
+const nextVersion = getNextVersion(currentVersion);
+
+// Update package.json
+packageJson.version = nextVersion;
+writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n', 'utf-8');
+
+console.log(`✓ Version updated: ${currentVersion} → ${nextVersion}`);


### PR DESCRIPTION
- These scripts are effective in the building phase; they are used for:
    - Generating the next version. =====> `increment-versions.js`
    - Generating manifest for `Firefox` and `Chromium` browsers. =====> `build-manifest.js`
    - Generate epub handling files during build. =====> `e-handler.js`
    - Copy common files to different addon collections; I mean for Firefox and Chrome separately. =====> `copy-assets.js`