### PR TITLE
v0.4.1: New version of epubespiar is now available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# I'm not using npm as my default manager, so:
+*package-lock.json
+
 node_modules
 dist
 dist-ssr

--- a/README.md
+++ b/README.md
@@ -133,6 +133,5 @@ When detected, it redirects to the extensions reader page, where you can read th
 ## What's not Implemented
 
 - [ ] Epub book library
-- [ ] Syntax highlighting
 - [ ] Download status: This shows the progress of your download
 - [ ] What you thought was but is not while using the extension

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "epubespiar",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite --config vite.dev.js",
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
     "cross-env": "^7.0.3",
+    "source-map-explorer": "^2.5.3",
     "vite": "^5.4.14",
     "vite-plugin-web-extension": "^4.0.0",
     "webextension-polyfill": "^0.10.0"


### PR DESCRIPTION
* add style retention, and syntax highlighting

* remove syntax highlighter

* added the source-map-explorer package as a new development dependency to help analyze JavaScript bundle sizes. To support this addition, the pnpm-lock.yaml file has been updated with source-map-explorer and its required dependencies.