### PR TITLE
Document version history and update README for v0.4.1 (#22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# I'm not using npm as my default manager, so:
+*package-lock.json
+
 node_modules
 dist
 dist-ssr

--- a/README.md
+++ b/README.md
@@ -126,13 +126,12 @@ When detected, it redirects to the extensions reader page, where you can read th
 
 ## Browser Compatibility
 
-- Chrome/Edge: Full support
-- Firefox: Full support
+- [Chrome](https://chromewebstore.google.com/detail/epubespiar/jpebliijmpohifmgjcpfmhfjjeingoho)/[Edge](https://microsoftedge.microsoft.com/addons/detail/mnlangghpjdaaecdfagjleijiahpaaei?hl=vi): Full support
+- [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/epubespiar/): Full support
 - Other Chromium-based browsers: Should work with the Chrome build
 
 ## What's not Implemented
 
 - [ ] Epub book library
-- [ ] Syntax highlighting
 - [ ] Download status: This shows the progress of your download
 - [ ] What you thought was but is not while using the extension

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,13 @@
+# Releases
+
+Not all the Releases will be listed, but the core ones.
+
+```
+0.0.1 --> 0.1.0 --> 0.2.0 --> 0.3.0
+```
+
+Unfortunately, I can't retrieve the first-ever release since it got lost when I deleted the first ever
+
+hosted version (0.0.1) from Firefox when I wanted to change the ID.
+
+I can't get it either from the edge store.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "epubespiar",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite --config vite.dev.js",
@@ -22,9 +22,7 @@
     "@vueuse/core": "^14.0.0",
     "axios": "^1.7.9",
     "core-js": "^3.8.3",
-    "dompurify": "^3.3.1",
     "dotenv": "^16.4.7",
-    "epubjs": "^0.3.93",
     "jszip": "^3.10.1",
     "lodash.throttle": "^4.1.1",
     "punycode": "^2.3.1",
@@ -33,10 +31,10 @@
     "vuex": "^4.1.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.4",
+    "@vitejs/plugin-vue": "^5.0.4",
     "cross-env": "^7.0.3",
-    "sass": "^1.97.1",
-    "vite": "^7.3.1",
+    "source-map-explorer": "^2.5.3",
+    "vite": "^5.4.14",
     "vite-plugin-web-extension": "^4.0.0",
     "webextension-polyfill": "^0.10.0"
   }


### PR DESCRIPTION
* epubespiar v0.4.0 (#19)

* Add RELEASES.md to document version history

Document core releases and note missing first release.

* Update README with new features and architecture (#20)

Provide url's to the extension

* v0.4.1: New version of epubespiar is now available (#21)

* Bump version from 0.4.0 to 0.4.1

* Update .gitignore to exclude additional config files

* Update README.md with enhanced formatting and content